### PR TITLE
add CI status badge (Go test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI for fuzz
+name: Go test
 
 on: push
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Golang playground
 
+![example workflow](https://github.com/miolab/go_playground/actions/workflows/ci.yml/badge.svg)
+
 ## About
 
 Golang playground and note for myself.


### PR DESCRIPTION
# About

Show CI `go test` status badge about GitHub Actions.

- image:
  <img width="105" alt="スクリーンショット 2022-05-22 8 00 14" src="https://user-images.githubusercontent.com/33124627/169671556-8902007f-1fcf-4b72-bc54-55cccc41b618.png">

- ref: https://github.com/miolab/go_playground/pull/19