### PR TITLE
chore/ Go version update to 1.20 (almost all dprojects)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Setup
     strategy:
       matrix:
-        go-version: [1.18.x, 1.17.x]
+        go-version: [1.18.x, 1.20.x]
     runs-on: ubuntu-20.04
     steps:
       - name: Init setup
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Cache Go
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'fuzz/go.mod'
       - name: Retrieve cached Go setup
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'example/greetings/go.mod'
       - name: Retrieve cached Go setup

--- a/example/greetings/go.mod
+++ b/example/greetings/go.mod
@@ -1,3 +1,3 @@
 module example.com/greetings
 
-go 1.17
+go 1.20

--- a/example/hello/go.mod
+++ b/example/hello/go.mod
@@ -1,6 +1,6 @@
 module example.com/hello
 
-go 1.17
+go 1.20
 
 replace example.com/greetings => ../greetings
 

--- a/function/go.mod
+++ b/function/go.mod
@@ -1,3 +1,3 @@
 module function
 
-go 1.17
+go 1.20

--- a/fuzz/Dockerfile
+++ b/fuzz/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.20-alpine
 
 WORKDIR /usr/src/app
 

--- a/fuzz/go.mod
+++ b/fuzz/go.mod
@@ -1,3 +1,3 @@
 module example/fuzz
 
-go 1.18
+go 1.20

--- a/random/go.mod
+++ b/random/go.mod
@@ -1,3 +1,3 @@
 module random
 
-go 1.17
+go 1.20

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,3 +1,3 @@
 module types
 
-go 1.17
+go 1.20


### PR DESCRIPTION
# About

- Update some projects Go version to 1.20.

```
go mod edit -go=1.20
```

- Update `actions/setup-go` version. (v3 -> v4)
  - https://github.com/actions/setup-go
    - https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

## Others

- ref: https://github.com/miolab/go_playground/pull/21